### PR TITLE
APIClientの作成

### DIFF
--- a/iOSEngineerCodeCheck/Common/Entity/GitHubRepositories.swift
+++ b/iOSEngineerCodeCheck/Common/Entity/GitHubRepositories.swift
@@ -1,0 +1,30 @@
+//
+//  GitHubRepositoryItem.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Tomoya Tanaka on 2022/02/22.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct GitHubRepositories: Decodable {
+    let items: [Item]
+}
+
+extension GitHubRepositories {
+    struct Item: Decodable {
+        let forksCount: Int
+        let fullName: String
+        let language: String?
+        let openIssuesCount: Int
+        let owner: Owner
+        let stargazersCount: Int
+        let watchersCount: Int
+    }
+
+    struct Owner: Decodable {
+        let avatarUrl: String
+    }
+}
+

--- a/iOSEngineerCodeCheck/Common/GitHubAPI/GitHubAPIClient.swift
+++ b/iOSEngineerCodeCheck/Common/GitHubAPI/GitHubAPIClient.swift
@@ -1,0 +1,37 @@
+//
+//  GitHubAPIClient.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Tomoya Tanaka on 2022/02/22.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+import Moya
+import RxSwift
+
+protocol GitHubAPIClientType {
+    func send<Response: Decodable>(targetType: TargetType, responseType: Response.Type) -> Single<Response>
+}
+
+final class GitHubAPIClient: GitHubAPIClientType {
+
+    let provider: MoyaProvider<MultiTarget>
+
+    init(
+        provider: MoyaProvider<MultiTarget>
+    ) {
+        self.provider = provider
+    }
+
+    func send<Response: Decodable>(targetType: TargetType, responseType: Response.Type) -> Single<Response> {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return provider.rx.request(MultiTarget(targetType))
+            .filterSuccessfulStatusCodes()
+            .map(Response.self, using: decoder)
+            .catch { error in
+                return Single.error(error)
+            }
+    }
+}

--- a/iOSEngineerCodeCheck/Common/GitHubAPI/SearchRepositoriesRequest.swift
+++ b/iOSEngineerCodeCheck/Common/GitHubAPI/SearchRepositoriesRequest.swift
@@ -1,0 +1,43 @@
+//
+//  SearchRepositoriesRequest.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Tomoya Tanaka on 2022/02/22.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+import Moya
+
+struct SearchRepositoriesRequest: TargetType {
+
+    let searchQuery: String
+
+    init(searchQuery: String) {
+        self.searchQuery = searchQuery
+    }
+
+    var baseURL: URL {
+        return URL(string: Environments.GitHubAPIURL)!
+    }
+
+    var path: String {
+        return "/search/repositories"
+    }
+
+    var method: Moya.Method {
+        return .get
+    }
+
+    var task: Task {
+        return .requestParameters(
+            parameters: ["q": searchQuery],
+            encoding: URLEncoding.default
+        )
+    }
+
+    var headers: [String : String]? {
+        return nil
+    }
+
+}


### PR DESCRIPTION
## 関連issue
[アーキテクチャを適用](https://github.com/Tomoya113/ios-engineer-codecheck/issues/6)

## 行ったこと
Moyaを使って、GitHubAPIとの通信周りをまとめるAPIClientを作成しました。

