### PR TITLE
APIClientのエラーハンドリング機能を実装

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		9F7B25F727C52E9E00369376 /* SearchRepositoriesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B25F627C52E9E00369376 /* SearchRepositoriesViewModel.swift */; };
 		9F7B25F927C6506F00369376 /* SearchRepositoriesRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B25F827C6506F00369376 /* SearchRepositoriesRouter.swift */; };
 		9F7B25FF27C6793500369376 /* RepositoryDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B25FE27C6793500369376 /* RepositoryDetailViewModel.swift */; };
+		9F7B260C27CA23A800369376 /* UnexpectedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B260B27CA23A800369376 /* UnexpectedError.swift */; };
+		9F7B261327CA2A7900369376 /* APIMockHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B261227CA2A7900369376 /* APIMockHelper.swift */; };
+		9F7B261527CA3A1E00369376 /* GitHubAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B261427CA3A1E00369376 /* GitHubAPIClientTests.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -63,6 +66,9 @@
 		9F7B25F627C52E9E00369376 /* SearchRepositoriesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesViewModel.swift; sourceTree = "<group>"; };
 		9F7B25F827C6506F00369376 /* SearchRepositoriesRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesRouter.swift; sourceTree = "<group>"; };
 		9F7B25FE27C6793500369376 /* RepositoryDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewModel.swift; sourceTree = "<group>"; };
+		9F7B260B27CA23A800369376 /* UnexpectedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnexpectedError.swift; sourceTree = "<group>"; };
+		9F7B261227CA2A7900369376 /* APIMockHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIMockHelper.swift; sourceTree = "<group>"; };
+		9F7B261427CA3A1E00369376 /* GitHubAPIClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GitHubAPIClientTests.swift; path = iOSEngineerCodeCheckTests/GitHubAPIClientTests.swift; sourceTree = SOURCE_ROOT; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -142,6 +148,7 @@
 			children = (
 				9F7B25EA27C51DF700369376 /* GitHubAPIClient.swift */,
 				9F7B25EC27C51ED800369376 /* SearchRepositoriesRequest.swift */,
+				9F7B260B27CA23A800369376 /* UnexpectedError.swift */,
 			);
 			path = GitHubAPI;
 			sourceTree = "<group>";
@@ -185,6 +192,29 @@
 			path = Common;
 			sourceTree = "<group>";
 		};
+		9F7B260527CA21D900369376 /* SearchRepositories */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SearchRepositories;
+			sourceTree = "<group>";
+		};
+		9F7B260D27CA246C00369376 /* GitHubAPIClient */ = {
+			isa = PBXGroup;
+			children = (
+				9F7B261427CA3A1E00369376 /* GitHubAPIClientTests.swift */,
+			);
+			path = GitHubAPIClient;
+			sourceTree = "<group>";
+		};
+		9F7B261027CA2A5E00369376 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				9F7B261227CA2A7900369376 /* APIMockHelper.swift */,
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
 		BFD945D2244DC5E80012785A = {
 			isa = PBXGroup;
 			children = (
@@ -226,6 +256,9 @@
 		BFD945F4244DC5EB0012785A /* iOSEngineerCodeCheckTests */ = {
 			isa = PBXGroup;
 			children = (
+				9F7B261027CA2A5E00369376 /* Helper */,
+				9F7B260D27CA246C00369376 /* GitHubAPIClient */,
+				9F7B260527CA21D900369376 /* SearchRepositories */,
 				BFD945F5244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift */,
 				BFD945F7244DC5EB0012785A /* Info.plist */,
 			);
@@ -517,6 +550,7 @@
 				9F7B25ED27C51ED800369376 /* SearchRepositoriesRequest.swift in Sources */,
 				9F7B25F327C520AA00369376 /* Environments.swift in Sources */,
 				9F7B25E627C51A5A00369376 /* GitHubRepositories.swift in Sources */,
+				9F7B260C27CA23A800369376 /* UnexpectedError.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				9F7B25EB27C51DF700369376 /* GitHubAPIClient.swift in Sources */,
@@ -532,7 +566,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9F7B261527CA3A1E00369376 /* GitHubAPIClientTests.swift in Sources */,
 				BFD945F6244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift in Sources */,
+				9F7B261327CA2A7900369376 /* APIMockHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck/Common/GitHubAPI/GitHubAPIClient.swift
+++ b/iOSEngineerCodeCheck/Common/GitHubAPI/GitHubAPIClient.swift
@@ -31,7 +31,10 @@ final class GitHubAPIClient: GitHubAPIClientType {
             .filterSuccessfulStatusCodes()
             .map(Response.self, using: decoder)
             .catch { error in
-                return Single.error(error)
+                if let error = error as? MoyaError {
+                    return .error(error)
+                }
+                return .error(UnexpectedError())
             }
     }
 }

--- a/iOSEngineerCodeCheck/Common/GitHubAPI/SearchRepositoriesRequest.swift
+++ b/iOSEngineerCodeCheck/Common/GitHubAPI/SearchRepositoriesRequest.swift
@@ -40,4 +40,41 @@ struct SearchRepositoriesRequest: TargetType {
         return nil
     }
 
+    var sampleData: Data {
+        return """
+        {
+            "items": [
+            {
+                "forks_count": 9438,
+                "full_name": "apple/swift",
+                "language": "C++",
+                "open_issues_count": 511,
+                "owner": {
+                    "avatar_url": "https://avatars.githubusercontent.com/u/10639145?v=4"
+                },
+                "stargazers_count": 58786,
+                "watchers_count": 58786
+            }
+
+            ]
+        }
+        """.data(using: .utf8)!
+    }
+
+    var errorResponseData: Data {
+        return """
+        {
+           "message":"Validation Failed",
+           "errors":[
+              {
+                 "resource":"Search",
+                 "field":"q",
+                 "code":"missing"
+              }
+           ],
+           "documentation_url":"https://docs.github.com/v3/search"
+        }
+        """.data(using: .utf8)!
+    }
+
 }

--- a/iOSEngineerCodeCheck/Common/GitHubAPI/UnexpectedError.swift
+++ b/iOSEngineerCodeCheck/Common/GitHubAPI/UnexpectedError.swift
@@ -1,0 +1,17 @@
+//
+//  UnexpectedError.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Tomoya Tanaka on 2022/02/26.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct UnexpectedError: Error {}
+
+extension UnexpectedError: LocalizedError {
+    var errorDescription: String? {
+        return "Unexpected error occured"
+    }
+}

--- a/iOSEngineerCodeCheckTests/GitHubAPIClientTests.swift
+++ b/iOSEngineerCodeCheckTests/GitHubAPIClientTests.swift
@@ -1,0 +1,102 @@
+//
+//  GitHubAPIClientTests.swift
+//  iOSEngineerCodeCheckTests
+//
+//  Created by Tomoya Tanaka on 2022/02/26.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+@testable import iOSEngineerCodeCheck
+@testable import Moya
+@testable import RxSwift
+import XCTest
+
+class GitHubAPIClientTests: XCTestCase {
+    let disposeBag = DisposeBag()
+    let searchRepositories = SearchRepositoriesRequest(searchQuery: "swift")
+    func testAPIResponseSuccess() {
+        let endpointClosure = { [searchRepositories] (target: MultiTarget) -> Endpoint in
+            return APIMockHelper.generateEndpoint(
+                target: target,
+                sampleResponse: .response(
+                    APIMockHelper.httpURLResponse(target: target, statusCode: 200),
+                    searchRepositories.sampleData
+                )
+            )
+        }
+        let stubbingProvider = MoyaProvider<MultiTarget>(endpointClosure: endpointClosure, stubClosure: MoyaProvider.immediatelyStub)
+
+        let apiClient = GitHubAPIClient(provider: stubbingProvider)
+
+        apiClient.send(targetType: searchRepositories, responseType: GitHubRepositories.self)
+            .subscribe(
+                onSuccess: { result in
+                    XCTAssertEqual(result.items.count, 1)
+                },
+                onFailure: { error in
+                    XCTFail("Test failed")
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    func testAPIResponseFailure() {
+        let endpointClosure = { [searchRepositories] (target: MultiTarget) -> Endpoint in
+            return APIMockHelper.generateEndpoint(
+                target: target,
+                sampleResponse: .networkResponse(422, searchRepositories.errorResponseData)
+            )
+        }
+        let stubbingProvider = MoyaProvider<MultiTarget>(endpointClosure: endpointClosure, stubClosure: MoyaProvider.immediatelyStub)
+
+        let apiClient = GitHubAPIClient(provider: stubbingProvider)
+
+        apiClient.send(targetType: searchRepositories, responseType: GitHubRepositories.self)
+            .subscribe(
+                onSuccess: { result in
+                    XCTFail("Test failed")
+                },
+                onFailure: { error in
+                    if let moyaError = error as? MoyaError {
+                        XCTAssertEqual(moyaError.localizedDescription, "Status code didn\'t fall within the given range.")
+                    } else {
+                        XCTFail("UnexpectedError occured")
+                    }
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
+    func testNetworkError() {
+        let endpointClosure = { (target: MultiTarget) -> Endpoint in
+            return APIMockHelper.generateEndpoint(
+                target: target,
+                sampleResponse: .networkError(NSError(domain: "CanNotConnectToHost", code: -1_004, userInfo: nil))
+            )
+        }
+        let stubbingProvider = MoyaProvider<MultiTarget>(endpointClosure: endpointClosure, stubClosure: MoyaProvider.immediatelyStub)
+
+        let apiClient = GitHubAPIClient(provider: stubbingProvider)
+
+        apiClient.send(targetType: searchRepositories, responseType: GitHubRepositories.self)
+            .subscribe(
+                onSuccess: { result in
+                    XCTFail("expected failure")
+                },
+                onFailure: { error in
+                    if let moyaError = error as? MoyaError {
+                        switch moyaError {
+                        case .underlying(let nsError as NSError, _):
+                            XCTAssertEqual(nsError.code, -1_004)
+                        default:
+                            XCTFail("Underlying error is expected")
+                        }
+                    } else {
+                        XCTFail("UnexpectedError occured")
+                    }
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+}
+

--- a/iOSEngineerCodeCheckTests/Helper/APIMockHelper.swift
+++ b/iOSEngineerCodeCheckTests/Helper/APIMockHelper.swift
@@ -1,0 +1,32 @@
+//
+//  APIMockHelper.swift
+//  iOSEngineerCodeCheckTests
+//
+//  Created by Tomoya Tanaka on 2022/02/26.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+@testable import Moya
+
+enum APIMockHelper {
+    static func generateEndpoint(target: MultiTarget, sampleResponse: EndpointSampleResponse) -> Endpoint {
+        return Endpoint(
+            url: URL(target: target).absoluteString,
+            sampleResponseClosure: {
+                sampleResponse
+            },
+            method: target.method,
+            task: target.task,
+            httpHeaderFields: target.headers
+        )
+    }
+
+    static func httpURLResponse(target: MultiTarget, statusCode: Int) -> HTTPURLResponse {
+        return HTTPURLResponse(
+            url: URL(target: target),
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}


### PR DESCRIPTION
## 関連issue
[テストを追加](https://github.com/Tomoya113/ios-engineer-codecheck/issues/9)

## 行ったこと
APIClientにエラーハンドリング機能を実装し、それに対するテストを実装しました。