### PR TITLE
SearchRepositoriesViewModelのリファクタリングとテストの追加

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -15,6 +15,7 @@ target 'iOSEngineerCodeCheck' do
 
   target 'iOSEngineerCodeCheckTests' do
     inherit! :search_paths
+		pod 'RxTest'
     # Pods for testing
   end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,6 +14,8 @@ PODS:
   - RxRelay (6.2.0):
     - RxSwift (= 6.2.0)
   - RxSwift (6.2.0)
+  - RxTest (6.2.0):
+    - RxSwift (= 6.2.0)
   - SwiftLint (0.45.1)
 
 DEPENDENCIES:
@@ -22,6 +24,7 @@ DEPENDENCIES:
   - Nuke
   - RxCocoa
   - RxSwift
+  - RxTest
   - SwiftLint
 
 SPEC REPOS:
@@ -32,6 +35,7 @@ SPEC REPOS:
     - RxCocoa
     - RxRelay
     - RxSwift
+    - RxTest
     - SwiftLint
 
 SPEC CHECKSUMS:
@@ -41,8 +45,9 @@ SPEC CHECKSUMS:
   RxCocoa: 4baf94bb35f2c0ab31bc0cb9f1900155f646ba42
   RxRelay: e72dbfd157807478401ef1982e1c61c945c94b2f
   RxSwift: d356ab7bee873611322f134c5f9ef379fa183d8f
+  RxTest: 0c692fa672b694373ba86d2b00033595297a2831
   SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
 
-PODFILE CHECKSUM: 8a37ac8a446fa09c6f3535bbfcc44c725cc2d73f
+PODFILE CHECKSUM: 5b2a7666ad07f55468174fe7b4ef7f419db98dde
 
 COCOAPODS: 1.11.2

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		9F7B262227CA4F4600369376 /* SearchRepositoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B262127CA4F4600369376 /* SearchRepositoriesModel.swift */; };
 		9F7B262527CA4FF600369376 /* GitHubRepositories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B262427CA4FF600369376 /* GitHubRepositories.swift */; };
 		9F7B262727CA515D00369376 /* GitHubRepositoriesRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B262627CA515D00369376 /* GitHubRepositoriesRepositoryMock.swift */; };
+		9FDAAF8B27CA620C006BFC4C /* SearchRepositoriesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDAAF8A27CA620C006BFC4C /* SearchRepositoriesViewModelTests.swift */; };
+		9FDAAF9027CA63D8006BFC4C /* SearchQueryValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDAAF8F27CA63D8006BFC4C /* SearchQueryValidator.swift */; };
 		BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -79,6 +81,8 @@
 		9F7B262127CA4F4600369376 /* SearchRepositoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesModel.swift; sourceTree = "<group>"; };
 		9F7B262427CA4FF600369376 /* GitHubRepositories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositories.swift; sourceTree = "<group>"; };
 		9F7B262627CA515D00369376 /* GitHubRepositoriesRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoriesRepositoryMock.swift; sourceTree = "<group>"; };
+		9FDAAF8A27CA620C006BFC4C /* SearchRepositoriesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoriesViewModelTests.swift; sourceTree = "<group>"; };
+		9FDAAF8F27CA63D8006BFC4C /* SearchQueryValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchQueryValidator.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -166,6 +170,7 @@
 		9F7B25FA27C651D200369376 /* SearchRepositories */ = {
 			isa = PBXGroup;
 			children = (
+				9FDAAF8C27CA63C0006BFC4C /* ViewModelHelper */,
 				9F7B25F827C6506F00369376 /* SearchRepositoriesRouter.swift */,
 				9F7B25F427C52D5D00369376 /* SearchRepositoriesModel.swift */,
 				9F7B25F627C52E9E00369376 /* SearchRepositoriesViewModel.swift */,
@@ -206,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				9F7B261927CA459000369376 /* SearchRepositoriesModelTests.swift */,
+				9FDAAF8A27CA620C006BFC4C /* SearchRepositoriesViewModelTests.swift */,
 			);
 			path = SearchRepositories;
 			sourceTree = "<group>";
@@ -242,6 +248,22 @@
 				9F7B262427CA4FF600369376 /* GitHubRepositories.swift */,
 			);
 			path = SampleData;
+			sourceTree = "<group>";
+		};
+		9FDAAF8C27CA63C0006BFC4C /* ViewModelHelper */ = {
+			isa = PBXGroup;
+			children = (
+				9FDAAF8D27CA63C5006BFC4C /* Validator */,
+			);
+			path = ViewModelHelper;
+			sourceTree = "<group>";
+		};
+		9FDAAF8D27CA63C5006BFC4C /* Validator */ = {
+			isa = PBXGroup;
+			children = (
+				9FDAAF8F27CA63D8006BFC4C /* SearchQueryValidator.swift */,
+			);
+			path = Validator;
 			sourceTree = "<group>";
 		};
 		BFD945D2244DC5E80012785A = {
@@ -595,6 +617,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BFD945E3244DC5E80012785A /* SearchRepositoriesViewController.swift in Sources */,
+				9FDAAF9027CA63D8006BFC4C /* SearchQueryValidator.swift in Sources */,
 				9F7B25F527C52D5D00369376 /* SearchRepositoriesModel.swift in Sources */,
 				9F7B25ED27C51ED800369376 /* SearchRepositoriesRequest.swift in Sources */,
 				9F7B25F327C520AA00369376 /* Environments.swift in Sources */,
@@ -620,6 +643,7 @@
 				9F7B262227CA4F4600369376 /* SearchRepositoriesModel.swift in Sources */,
 				9F7B261527CA3A1E00369376 /* GitHubAPIClientTests.swift in Sources */,
 				BFD945F6244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift in Sources */,
+				9FDAAF8B27CA620C006BFC4C /* SearchRepositoriesViewModelTests.swift in Sources */,
 				9F7B261A27CA459000369376 /* SearchRepositoriesModelTests.swift in Sources */,
 				9F7B262527CA4FF600369376 /* GitHubRepositories.swift in Sources */,
 				9F7B261327CA2A7900369376 /* APIMockHelper.swift in Sources */,

--- a/iOSEngineerCodeCheck/Pages/SearchRepositories/ViewModelHelper/Validator/SearchQueryValidator.swift
+++ b/iOSEngineerCodeCheck/Pages/SearchRepositories/ViewModelHelper/Validator/SearchQueryValidator.swift
@@ -1,0 +1,50 @@
+//
+//  SearchQueryValidator.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Tomoya Tanaka on 2022/02/26.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import RxCocoa
+import RxSwift
+
+class SearchQueryValidator {
+    enum ValidationResult {
+        case valid(searchQuery: String)
+        case searchQueryEmpty
+    }
+
+    static func validate(_ searchQuery: String) -> ValidationResult {
+        if searchQuery.isEmpty {
+            return .searchQueryEmpty
+        }
+        return .valid(searchQuery: searchQuery)
+    }
+}
+
+
+extension ObservableType where Element == SearchQueryValidator.ValidationResult {
+    func filterValid() -> Observable<String> {
+        return flatMap { validationResult -> Observable<String> in
+            switch validationResult {
+            case .valid(let searchWord):
+                return .just(searchWord)
+            default:
+                return .empty()
+            }
+        }
+    }
+
+    func filterSearchQueryEmpty() -> Observable<Bool> {
+        return flatMap { validationResult -> Observable<Bool> in
+            switch validationResult {
+            case .searchQueryEmpty:
+                return .just(true)
+            default:
+                return .empty()
+            }
+        }
+
+    }
+}

--- a/iOSEngineerCodeCheckTests/SearchRepositories/SearchRepositoriesViewModelTests.swift
+++ b/iOSEngineerCodeCheckTests/SearchRepositories/SearchRepositoriesViewModelTests.swift
@@ -1,0 +1,138 @@
+//
+//  SearchRepositoriesViewModelTests.swift
+//  iOSEngineerCodeCheckTests
+//
+//  Created by Tomoya Tanaka on 2022/02/26.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+@testable import iOSEngineerCodeCheck
+@testable import RxSwift
+@testable import RxTest
+import XCTest
+
+class SearchRepositoriesViewModelTests: XCTestCase {
+
+    let dependency = Dependency()
+
+    func testSearchQueryInputValid() throws {
+        let searchQueryEvent = dependency.testScheduler.createHotObservable([
+            Recorded.next(1, "swift")
+        ]).asObservable()
+
+        let repositoriesObserver = dependency.testScheduler.createObserver([GitHubRepositories.Item].self)
+        let loadingObserver = dependency.testScheduler.createObserver(Bool.self)
+
+
+        searchQueryEvent
+            .bind(to: dependency.testTarget.searchQuery)
+            .disposed(by: dependency.disposeBag)
+
+        dependency.testTarget.outputs.repositories
+            .asObservable()
+            .bind(to: repositoriesObserver)
+            .disposed(by: dependency.disposeBag)
+
+        dependency.testTarget.outputs.loading
+            .asObservable()
+            .bind(to: loadingObserver)
+            .disposed(by: dependency.disposeBag)
+
+        dependency.testScheduler.start()
+
+        let repositoriesResult = repositoriesObserver.events.map { $0.value.element }
+        let loadingResult = loadingObserver.events.map { $0.value.element }
+
+        XCTAssertEqual(repositoriesResult.last??.count, GitHubRepositories.expectedData.items.count)
+        XCTAssertEqual(loadingResult, [true, false])
+    }
+
+    func testSearchQueryInputInvalid() throws {
+        let searchQueryEvent = dependency.testScheduler.createHotObservable([
+            Recorded.next(1, "")
+        ]).asObservable()
+
+        let repositoriesObserver = dependency.testScheduler.createObserver([GitHubRepositories.Item].self)
+        let loadingObserver = dependency.testScheduler.createObserver(Bool.self)
+        let hasSearchQueryEmptyErrorObserver = dependency.testScheduler.createObserver(Bool.self)
+
+        searchQueryEvent
+            .bind(to: dependency.testTarget.searchQuery)
+            .disposed(by: dependency.disposeBag)
+
+        dependency.testTarget.outputs.repositories
+            .asObservable()
+            .bind(to: repositoriesObserver)
+            .disposed(by: dependency.disposeBag)
+
+        dependency.testTarget.outputs.loading
+            .asObservable()
+            .bind(to: loadingObserver)
+            .disposed(by: dependency.disposeBag)
+
+        dependency.testTarget.outputs.hasSearchQueryEmptyError
+            .asObservable()
+            .bind(to: hasSearchQueryEmptyErrorObserver)
+            .disposed(by: dependency.disposeBag)
+
+        dependency.testScheduler.start()
+
+        let repositoriesResult = repositoriesObserver.events.map { $0.value.element }
+        let loadingResult = loadingObserver.events.map { $0.value.element }
+        let hasSearchQueryEmptyErrorResult = hasSearchQueryEmptyErrorObserver.events.map { $0.value.element }
+
+        XCTAssertEqual(repositoriesResult.count, 1)
+        XCTAssertEqual(loadingResult, [])
+        XCTAssertEqual(hasSearchQueryEmptyErrorResult, [true])
+
+    }
+
+    func testSelectedItemIndexSuccess() throws {
+        let searchQueryEvent = dependency.testScheduler.createHotObservable([
+            Recorded.next(0, "swift")
+        ]).asObservable()
+
+        let selectedItemIndexEvent = dependency.testScheduler.createHotObservable([
+            Recorded.next(1, IndexPath(row: GitHubRepositories.expectedData.items.count - 1, section: 1))
+        ]).asObservable()
+
+        let selectedItemObserver = dependency.testScheduler.createObserver(GitHubRepositories.Item.self)
+
+        searchQueryEvent
+            .bind(to: dependency.testTarget.inputs.searchQuery)
+            .disposed(by: dependency.disposeBag)
+
+        selectedItemIndexEvent
+            .bind(to: dependency.testTarget.inputs.selectedItemIndex)
+            .disposed(by: dependency.disposeBag)
+
+        dependency.testTarget.outputs.selectedItem
+            .asObservable()
+            .bind(to: selectedItemObserver)
+            .disposed(by: dependency.disposeBag)
+
+        dependency.testScheduler.start()
+
+        let selectedItemResult = selectedItemObserver.events.map { $0.value.element }
+
+        XCTAssertEqual(selectedItemResult.count, 1)
+
+    }
+}
+
+
+extension SearchRepositoriesViewModelTests {
+    struct Dependency {
+        let disposeBag: DisposeBag
+        let testScheduler: TestScheduler
+        let searchRepositoriesModelMock: SearchRepositoriesModelMock
+        let testTarget: SearchRepositoriesViewModel
+
+        init() {
+            disposeBag = DisposeBag()
+            testScheduler = TestScheduler(initialClock: 0)
+            searchRepositoriesModelMock = SearchRepositoriesModelMock()
+            testTarget = SearchRepositoriesViewModel(model: searchRepositoriesModelMock)
+        }
+    }
+}


### PR DESCRIPTION
## 関連issue
[テストを追加](https://github.com/Tomoya113/ios-engineer-codecheck/issues/9)

## 行ったこと
SearchRepositoriesViewModelにバリデーション機能の追加とローディング管理機能の追加を行い、それに対するテストを追加しました。