### PR TITLE
リポジトリ検索画面にバリデーションとローディング機能を追加

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,6 +9,7 @@ target 'iOSEngineerCodeCheck' do
 	pod 'Moya'
 	pod 'Moya/RxSwift'
 	pod 'Nuke'
+	pod 'PKHUD'
 	pod 'RxCocoa'
 	pod 'RxSwift'
 	pod 'SwiftLint'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,6 +8,7 @@ PODS:
     - Moya/Core
     - RxSwift (~> 6.0)
   - Nuke (10.7.1)
+  - PKHUD (5.3.0)
   - RxCocoa (6.2.0):
     - RxRelay (= 6.2.0)
     - RxSwift (= 6.2.0)
@@ -22,6 +23,7 @@ DEPENDENCIES:
   - Moya
   - Moya/RxSwift
   - Nuke
+  - PKHUD
   - RxCocoa
   - RxSwift
   - RxTest
@@ -32,6 +34,7 @@ SPEC REPOS:
     - Alamofire
     - Moya
     - Nuke
+    - PKHUD
     - RxCocoa
     - RxRelay
     - RxSwift
@@ -42,12 +45,13 @@ SPEC CHECKSUMS:
   Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   Nuke: 279f17a599fd1c83cf51de5e0e1f2db143a287b0
+  PKHUD: 98f3e4bc904b9c916f1c5bb6d765365b5357291b
   RxCocoa: 4baf94bb35f2c0ab31bc0cb9f1900155f646ba42
   RxRelay: e72dbfd157807478401ef1982e1c61c945c94b2f
   RxSwift: d356ab7bee873611322f134c5f9ef379fa183d8f
   RxTest: 0c692fa672b694373ba86d2b00033595297a2831
   SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
 
-PODFILE CHECKSUM: 5b2a7666ad07f55468174fe7b4ef7f419db98dde
+PODFILE CHECKSUM: 0e2bc17d2c639443bd443e6ce0741ced4bdf873f
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
## 関連issue
[新機能を追加](https://github.com/Tomoya113/ios-engineer-codecheck/issues/8)

## 行ったこと
以下の機能を追加しました。
- リポジトリ検索画面にローディング機能
- 検索バーに文字がない場合にリクエストが送られた時にアラートを出す機能

## スクリーンショット
| 1 | 2 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/22112440/155910547-c4373a90-b178-4af9-a62b-86eb5ed87d31.png" width="400px"> | <img src="https://user-images.githubusercontent.com/22112440/155910552-09f2bd00-1d8a-4cec-8adf-18491d0d883c.png" width="400px"> |


