### PR TITLE
リポジトリ検索機能にエラーハンドリング機能を追加

### DIFF
--- a/iOSEngineerCodeCheck/Pages/SearchRepositories/SearchRepositoriesViewController.swift
+++ b/iOSEngineerCodeCheck/Pages/SearchRepositories/SearchRepositoriesViewController.swift
@@ -87,6 +87,13 @@ final class SearchRepositoriesViewController: UITableViewController {
                 self.presentSearchQueryEmptyAlert()
             })
             .disposed(by: disposeBag)
+
+        viewModel.outputs.error
+            .drive(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.presentErrorAlert()
+            })
+            .disposed(by: disposeBag)
     }
 
     private func setupView() {
@@ -98,6 +105,18 @@ final class SearchRepositoriesViewController: UITableViewController {
         let alert = UIAlertController(
             title: "エラー",
             message: "1文字以上文字を入力してください",
+            preferredStyle: .alert
+        )
+        let alertAction = UIAlertAction(title: "閉じる", style: .default, handler: nil)
+
+        alert.addAction(alertAction)
+        self.present(alert, animated: true, completion: nil)
+    }
+
+    private func presentErrorAlert() {
+        let alert = UIAlertController(
+            title: "エラー",
+            message: "何らかのエラーが発生しました。",
             preferredStyle: .alert
         )
         let alertAction = UIAlertAction(title: "閉じる", style: .default, handler: nil)


### PR DESCRIPTION
## 関連issue
[新機能を追加](https://github.com/Tomoya113/ios-engineer-codecheck/issues/8)

## 行ったこと
リポジトリ検索機能にエラーハンドリング機能の追加に伴い以下の実装を行いました。

cf5b66b9e42ebeb8de6c1364c6a2f85378a62492
- ViewModelにエラーハンドリング機能の実装
- ViewModelのプロパティの順番を修正

86cc532a616b855326a94ff23b4cfa0e91ac5004
- ViewModelにテストを追加

9fc708e82a72b12d0528fcdf895e951024c568fd
- ViewControllerにエラーが発生したときのアラートの追加

## スクリーンショット
 <img src="https://user-images.githubusercontent.com/22112440/155918378-05b54d92-8c66-4475-b75f-eaff0903fbd2.png" width="400px">



